### PR TITLE
Relocate to correct coordinates including version and artifactId.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,9 @@
 	<distributionManagement>
 		<relocation>
 			<groupId>io.kokuwa.maven</groupId>
+			<artifactId>helm-maven-plugin</artifactId>
+			<version>6.0.0</version>
+			<message>https://github.com/kokuwaio is the new maintainer</message>
 		</relocation>
 		<repository>
 			<id>sonatype-nexus</id>


### PR DESCRIPTION
Relocate was missing new major version. See #157 

New Version must be published to maven central.