### PR TITLE
Improve Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	</developers>
 
 	<prerequisites>
-		<maven>3.0.5</maven>
+		<maven>${version.maven}</maven>
 	</prerequisites>
 
 	<scm>
@@ -84,13 +84,15 @@
 		<!-- ============================= Versions ============================== -->
 		<!-- ===================================================================== -->
 
+		<version.maven>3.6.1</version.maven>
+		<version.maven.plugin.tools>3.6.4</version.maven.plugin.tools>
+
 		<!-- dependencies -->
 
 		<version.org.apache.commons.compress>1.21</version.org.apache.commons.compress>
 		<version.org.apache.commons.io>2.7</version.org.apache.commons.io>
-		<version.org.apache.maven.plugin.annotations>3.6.0</version.org.apache.maven.plugin.annotations>
-		<version.org.apache.maven.plugin.api>3.6.1</version.org.apache.maven.plugin.api>
-		<version.org.apache.maven.settings>3.6.1</version.org.apache.maven.settings>
+		<version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
+		<version.org.codehaus.plexus.utils>3.4.1</version.org.codehaus.plexus.utils>
 		<version.org.junit.jupiter>5.4.2</version.org.junit.jupiter>
 		<version.org.mockito>2.28.2</version.org.mockito>
 		<version.org.projectlombok>1.18.12</version.org.projectlombok>
@@ -106,7 +108,6 @@
 		<version.org.apache.maven.plugins.invoker>3.2.2</version.org.apache.maven.plugins.invoker>
 		<version.org.apache.maven.plugins.javadoc>3.3.1</version.org.apache.maven.plugins.javadoc>
 		<version.org.apache.maven.plugins.jar>3.2.1</version.org.apache.maven.plugins.jar>
-		<version.org.apache.maven.plugins.plugin_>3.6.0</version.org.apache.maven.plugins.plugin_>
 		<version.org.apache.maven.plugins.release>3.0.0-M5</version.org.apache.maven.plugins.release>
 		<version.org.apache.maven.plugins.resources>3.2.0</version.org.apache.maven.plugins.resources>
 		<version.org.apache.maven.plugins.source>3.2.1</version.org.apache.maven.plugins.source>
@@ -122,18 +123,30 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>${version.org.apache.maven.plugin.api}</version>
+			<version>${version.maven}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-settings</artifactId>
-			<version>${version.org.apache.maven.settings}</version>
+			<version>${version.maven}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${version.org.apache.commons.lang3}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>${version.org.apache.maven.plugin.annotations}</version>
+			<version>${version.maven.plugin.tools}</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>${version.org.codehaus.plexus.utils}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.sonatype.plexus</groupId>
@@ -225,7 +238,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
-					<version>${version.org.apache.maven.plugins.plugin_}</version>
+					<version>${version.maven.plugin.tools}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- prerequisites.maven - should be the same as used Maven Api version
- Maven core artifacts g:org.apache.maven should be in provided scope
- maven-plugin-annotations and maven-plugin-plugin come from the same project - so version should be the same