### PR TITLE
add capability to push to OCI registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ and disables the auto-detection feature:
 - `helm:template` Locally render templates
 - `helm:dry-run` simulates an install
 - `helm:upload` upload charts via HTTP PUT
+- `helm:push` push charts to OCI (docker registry)
 
 ## Configuration
 

--- a/src/main/java/io/kokuwa/maven/helm/PushMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/PushMojo.java
@@ -24,7 +24,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 @Mojo(name = "push", defaultPhase = LifecyclePhase.DEPLOY)
 public class PushMojo extends AbstractHelmMojo {
 
-    private static final String LOGIN_COMMAND_TEMPLATE = " registry login -u %s -p %s %s ";
+    private static final String LOGIN_COMMAND_TEMPLATE = " registry login -u %s %s --password-stdin ";
     private static final String CHART_PUSH_TEMPLATE = " push %s oci://%s ";
 
     @Parameter(property = "helm.push.skip", defaultValue = "false")
@@ -48,9 +48,8 @@ public class PushMojo extends AbstractHelmMojo {
                         format(
                                 LOGIN_COMMAND_TEMPLATE,
                                 registry.getUsername(),
-                                registry.getPassword(),
                                 registry.getUrl()),
-                        EMPTY, true);
+                        "can't login to registry", true, registry.getPassword());
 
         getLog().info("Uploading to " + registry.getUrl());
         getChartTgzs(getOutputDirectory())

--- a/src/main/java/io/kokuwa/maven/helm/PushMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/PushMojo.java
@@ -47,7 +47,7 @@ public class PushMojo extends AbstractHelmMojo {
         ComparableVersion helmVersion = new ComparableVersion(getHelmVersion());
         ComparableVersion minimumHelmVersion = new ComparableVersion("3.8.0");
         if(helmVersion.compareTo(minimumHelmVersion) < 0) {
-            getLog().error("your helm version is " + helmVersion.toString() + ", it's require to be >=3.8.0");
+            getLog().error("your helm version is " + helmVersion.toString() + ", it's required to be >=3.8.0");
             throw new IllegalStateException();
         }
         else {

--- a/src/main/java/io/kokuwa/maven/helm/PushMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/PushMojo.java
@@ -1,0 +1,91 @@
+package io.kokuwa.maven.helm;
+
+import io.kokuwa.maven.helm.pojo.HelmRepository;
+import lombok.Data;
+import lombok.SneakyThrows;
+import org.apache.commons.compress.utils.FileNameUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+@Data
+@Mojo(name = "push", defaultPhase = LifecyclePhase.DEPLOY)
+public class PushMojo extends AbstractHelmMojo {
+
+    private static final String LOGIN_COMMAND_TEMPLATE = " registry login -u %s -p %s %s ";
+    private static final String CHART_PUSH_TEMPLATE = " push %s oci://%s ";
+
+    @Parameter(property = "helm.push.skip", defaultValue = "false")
+    private boolean skipPush;
+
+    @SneakyThrows
+    public void execute() {
+
+        if (skip || skipPush) {
+            getLog().info("Skip push");
+            return;
+        }
+        final HelmRepository registry = getHelmUploadRepo();
+        if (Objects.isNull(registry)) {
+            getLog().info("there is no helm repo. skipping the upload.");
+            return;
+        }
+
+        callCli(
+                getHelmExecuteablePath() +
+                        format(
+                                LOGIN_COMMAND_TEMPLATE,
+                                registry.getUsername(),
+                                registry.getPassword(),
+                                registry.getUrl()),
+                        EMPTY, true);
+
+        getLog().info("Uploading to " + registry.getUrl());
+        getChartTgzs(getOutputDirectory())
+                .forEach(
+                        chartTgzFile -> {
+                            getLog().info("Uploading " + chartTgzFile);
+                            try {
+                                uploadSingle(Paths.get(chartTgzFile), registry);
+                            } catch (MojoExecutionException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+    }
+
+    private void uploadSingle(Path tgz, HelmRepository registry) throws MojoExecutionException {
+
+        callCli(
+                getHelmExecuteablePath() +
+                        format(
+                                CHART_PUSH_TEMPLATE,
+                                tgz,
+                                registry.getUrl()),
+                        EMPTY, true);
+    }
+
+    List<String> getChartTgzs(String path) throws MojoExecutionException {
+
+        try (Stream<Path> files = Files.walk(Paths.get(path))) {
+            return files
+                    .filter(p -> FileNameUtils.getExtension(p.toFile().getName()).equals("tgz"))
+                    .map(Path::toString)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Unable to scan repo directory at " + path, e);
+        }
+    }
+}
+

--- a/src/main/java/io/kokuwa/maven/helm/PushMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/PushMojo.java
@@ -4,6 +4,7 @@ import io.kokuwa.maven.helm.pojo.HelmRepository;
 import lombok.Data;
 import lombok.SneakyThrows;
 import org.apache.commons.compress.utils.FileNameUtils;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -41,6 +42,16 @@ public class PushMojo extends AbstractHelmMojo {
         if (Objects.isNull(registry)) {
             getLog().info("there is no helm repo. skipping the upload.");
             return;
+        }
+
+        ComparableVersion helmVersion = new ComparableVersion(getHelmVersion());
+        ComparableVersion minimumHelmVersion = new ComparableVersion("3.8.0");
+        if(helmVersion.compareTo(minimumHelmVersion) < 0) {
+            getLog().error("your helm version is " + helmVersion.toString() + ", it's require to be >=3.8.0");
+            throw new IllegalStateException();
+        }
+        else {
+            getLog().debug("helm version minimum satisfied. the version is: "+ helmVersion.toString());
         }
 
         callCli(

--- a/src/main/java/io/kokuwa/maven/helm/PushMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/PushMojo.java
@@ -54,13 +54,15 @@ public class PushMojo extends AbstractHelmMojo {
             getLog().debug("helm version minimum satisfied. the version is: "+ helmVersion.toString());
         }
 
-        callCli(
-                getHelmExecuteablePath() +
-                        format(
-                                LOGIN_COMMAND_TEMPLATE,
-                                registry.getUsername(),
-                                registry.getUrl()),
-                        "can't login to registry", true, registry.getPassword());
+        if (registry.getUsername() != null && registry.getPassword() == null) {
+            callCli(
+                    getHelmExecuteablePath() +
+                            format(
+                                    LOGIN_COMMAND_TEMPLATE,
+                                    registry.getUsername(),
+                                    registry.getUrl()),
+                    "can't login to registry", true, registry.getPassword());
+        }
 
         getLog().info("Uploading to " + registry.getUrl());
         getChartTgzs(getOutputDirectory())


### PR DESCRIPTION
pushing helm chart to OCI registry (like `docker registry`) added by default from `helm >= v3.8.0` 
as a feature request needed here #120 , I added the ability to push helm chart to OCI registries. 