### PR TITLE
Centralized helm config & cache, added --debug flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Parameter | Type | User Property | Required | Description
 `<autoDetectLocalHelmBinary>` | boolean | helm.autoDetectLocalHelmBinary | true | Controls whether the local binary should be auto-detected from `PATH` environment variable. If set to `false` the binary in `<helmExecutableDirectory>` is used. This property has no effect unless `<useLocalHelmBinary>` is set to `true`.
 `<helmExecutableDirectory>` | string | helm.executableDirectory | false | directory of your helm installation (default: `${project.build.directory}/helm`)
 `<outputDirectory>` | string | helm.outputDirectory | false | chart output directory (default: `${project.build.directory}/helm/repo`)
+`<debug>` | boolean | helm.debug | false | add debug to helm
 `<registryConfig>` | string | helm.registryConfig | false | path to the registry config file
 `<repositoryCache>` | string | helm.repositoryCache | false | path to the file containing cached repository indexes
 `<repositoryConfig>` | string | helm.repositoryConfig | false | path to the file containing repository names and URLs

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>io.kokuwa.maven</groupId>
 	<artifactId>helm-maven-plugin</artifactId>
-	<version>6.1.2-SNAPSHOT</version>
+	<version>6.2.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>Helm Maven Plugin</name>

--- a/src/main/java/io/kokuwa/maven/helm/DependencyBuildMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/DependencyBuildMojo.java
@@ -4,7 +4,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.plexus.util.StringUtils;
 
 import lombok.Setter;
 
@@ -31,15 +30,7 @@ public class DependencyBuildMojo extends AbstractHelmMojo {
 
 		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
 			getLog().info("Build chart dependencies for " + inputDirectory + "...");
-			callCli(getHelmExecuteablePath()
-					+ " dependency build "
-					+ inputDirectory
-					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
-					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache()
-							: "")
-					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig()
-							: ""),
-					"Failed to resolve dependencies");
+			helm("dependency build " + inputDirectory, "Failed to resolve dependencies");
 		}
 	}
 }

--- a/src/main/java/io/kokuwa/maven/helm/DryRunMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/DryRunMojo.java
@@ -4,7 +4,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.plexus.util.StringUtils;
 
 import lombok.Setter;
 
@@ -34,17 +33,8 @@ public class DryRunMojo extends AbstractHelmWithValueOverrideMojo {
 
 		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
 			getLog().info("\n\nPerform dry-run for chart " + inputDirectory + "...");
-			callCli(getHelmExecuteablePath()
-					+ " " + action
-					+ " " + inputDirectory
-					+ " --dry-run --generate-name"
-					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
-					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache()
-							: "")
-					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig()
-							: "")
-					+ getValuesOptions(),
-					"There are test failures");
+			String arguments = action + " " + inputDirectory + " --dry-run --generate-name" + getValuesOptions();
+			helm(arguments, "There are test failures");
 		}
 	}
 }

--- a/src/main/java/io/kokuwa/maven/helm/InitMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/InitMojo.java
@@ -131,18 +131,11 @@ public class InitMojo extends AbstractHelmMojo {
 			throws MojoExecutionException {
 		getLog().info("Adding repo [" + repository + "]");
 		PasswordAuthentication auth = authenticationRequired ? getAuthentication(repository) : null;
-		callCli(getHelmExecuteablePath()
-				+ " repo add "
-				+ repository.getName()
-				+ " "
-				+ repository.getUrl()
-				+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
-				+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache() : "")
-				+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig() : "")
-				+ (auth != null
-						? " --username=" + auth.getUserName() + " --password=" + String.valueOf(auth.getPassword())
-						: ""),
-				"Unable add repo");
+		String arguments = "repo add " + repository.getName() + " " + repository.getUrl();
+		if (auth != null) {
+			arguments += " --username=" + auth.getUserName() + " --password=" + String.valueOf(auth.getPassword());
+		}
+		helm(arguments, "Unable add repo");
 	}
 
 	protected void downloadAndUnpackHelm() throws MojoExecutionException {
@@ -231,7 +224,7 @@ public class InitMojo extends AbstractHelmMojo {
 	}
 
 	private void verifyLocalHelmBinary() throws MojoExecutionException {
-		callCli(getHelmExecuteablePath() + " version", "Unable to verify local HELM binary");
+		helm("version", "Unable to verify local HELM binary");
 	}
 
 	private ArchiveInputStream createArchiverInputStream(InputStream is) throws MojoExecutionException {

--- a/src/main/java/io/kokuwa/maven/helm/InstallMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/InstallMojo.java
@@ -37,16 +37,8 @@ public class InstallMojo extends AbstractHelmWithValueOverrideMojo {
 		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
 			getLog().info(String.format("\n\nPerform install for chart %s...", inputDirectory));
 			String clusterName = new File(inputDirectory).getName();
-			callCli(String.format("%s %s %s %s %s %s %s %s",
-					getHelmExecuteablePath(),
-					action,
-					clusterName,
-					inputDirectory,
-					formatIfValueIsNotEmpty("--registry-config=%s", getRegistryConfig()),
-					formatIfValueIsNotEmpty("--repository-cache=%s", getRepositoryCache()),
-					formatIfValueIsNotEmpty("--repository-config=%s", getRepositoryConfig()),
-					getValuesOptions()),
-					"Failed to deploy helm chart");
+			String arguments = String.format("%s %s %s %s", action, clusterName, inputDirectory, getValuesOptions());
+			helm(arguments, "Failed to deploy helm chart");
 		}
 	}
 }

--- a/src/main/java/io/kokuwa/maven/helm/LintMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/LintMojo.java
@@ -4,7 +4,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.plexus.util.StringUtils;
 
 import lombok.Setter;
 
@@ -34,17 +33,8 @@ public class LintMojo extends AbstractHelmWithValueOverrideMojo {
 
 		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
 			getLog().info("\n\nTesting chart " + inputDirectory + "...");
-			callCli(getHelmExecuteablePath()
-					+ " lint "
-					+ inputDirectory
-					+ (lintStrict ? " --strict" : "")
-					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
-					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache()
-							: "")
-					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig()
-							: "")
-					+ getValuesOptions(),
-					"There are test failures");
+			String arguments = "lint " + inputDirectory + (lintStrict ? " --strict" : "") + getValuesOptions();
+			helm(arguments, "There are test failures");
 		}
 	}
 }

--- a/src/main/java/io/kokuwa/maven/helm/PackageMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/PackageMojo.java
@@ -41,38 +41,29 @@ public class PackageMojo extends AbstractHelmMojo {
 		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
 			getLog().info("Packaging chart " + inputDirectory + "...");
 
-			String helmCommand = getHelmExecuteablePath()
-					+ " package "
-					+ inputDirectory
-					+ " -d "
-					+ getOutputDirectory()
-					+ (StringUtils.isNotEmpty(getRegistryConfig()) ? " --registry-config=" + getRegistryConfig() : "")
-					+ (StringUtils.isNotEmpty(getRepositoryCache()) ? " --repository-cache=" + getRepositoryCache()
-							: "")
-					+ (StringUtils.isNotEmpty(getRepositoryConfig()) ? " --repository-config=" + getRepositoryConfig()
-							: "");
+			String arguments = "package " + inputDirectory + " -d " + getOutputDirectory();
 
 			if (getChartVersion() != null) {
 				getLog().info(String.format("Setting chart version to %s", getChartVersionWithProcessing()));
-				helmCommand = helmCommand + " --version " + getChartVersionWithProcessing();
+				arguments += " --version " + getChartVersionWithProcessing();
 			}
 
 			if (getAppVersion() != null) {
 				getLog().info(String.format("Setting App version to %s", getAppVersion()));
-				helmCommand = helmCommand + " --app-version " + getAppVersion();
+				arguments += " --app-version " + getAppVersion();
 			}
 
 			String stdin = null;
 			if (isSignEnabled()) {
 				getLog().info("Enable signing");
-				helmCommand = helmCommand + " --sign --keyring " + keyring + " --key " + key;
+				arguments += " --sign --keyring " + keyring + " --key " + key;
 				if (StringUtils.isNotEmpty(passphrase)) {
-					helmCommand += " --passphrase-file -";
+					arguments += " --passphrase-file -";
 					stdin = passphrase;
 				}
 			}
 
-			callCli(helmCommand, "Unable to package chart at " + inputDirectory, stdin);
+			helm(arguments, "Unable to package chart at " + inputDirectory, stdin);
 		}
 	}
 

--- a/src/main/java/io/kokuwa/maven/helm/PushMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/PushMojo.java
@@ -1,8 +1,5 @@
 package io.kokuwa.maven.helm;
 
-import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -56,13 +53,8 @@ public class PushMojo extends AbstractHelmMojo {
 		}
 
 		if (registry.getUsername() != null && registry.getPassword() != null) {
-			callCli(
-					getHelmExecuteablePath() +
-							format(
-									LOGIN_COMMAND_TEMPLATE,
-									registry.getUsername(),
-									registry.getUrl()),
-					"can't login to registry", registry.getPassword());
+			String arguments = String.format(LOGIN_COMMAND_TEMPLATE, registry.getUsername(), registry.getUrl());
+			helm(arguments, "can't login to registry", registry.getPassword());
 		}
 
 		getLog().info("Uploading to " + registry.getUrl());
@@ -79,13 +71,7 @@ public class PushMojo extends AbstractHelmMojo {
 	}
 
 	private void uploadSingle(Path tgz, HelmRepository registry) throws MojoExecutionException {
-		callCli(
-				getHelmExecuteablePath() +
-						format(
-								CHART_PUSH_TEMPLATE,
-								tgz,
-								registry.getUrl()),
-				EMPTY);
+		helm(String.format(CHART_PUSH_TEMPLATE, tgz, registry.getUrl()), "Upload failed");
 	}
 
 	List<String> getChartTgzs(String path) throws MojoExecutionException {

--- a/src/main/java/io/kokuwa/maven/helm/TemplateMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/TemplateMojo.java
@@ -38,14 +38,10 @@ public class TemplateMojo extends AbstractHelmWithValueOverrideMojo {
 
 		for (String inputDirectory : getChartDirectories(getChartDirectory())) {
 			getLog().info(String.format("\n\nPerform template for chart %s...", inputDirectory));
-			callCli(String.format("%s %s %s %s %s %s %s %s",
-					getHelmExecuteablePath(),
+			helm(String.format("%s %s %s %s",
 					action,
 					inputDirectory,
 					StringUtils.isNotEmpty(additionalArguments) ? additionalArguments : "",
-					formatIfValueIsNotEmpty("--registry-config=%s", getRegistryConfig()),
-					formatIfValueIsNotEmpty("--repository-cache=%s", getRepositoryCache()),
-					formatIfValueIsNotEmpty("--repository-config=%s", getRepositoryConfig()),
 					getValuesOptions()),
 					"There are test failures");
 		}

--- a/src/test/java/io/kokuwa/maven/helm/LintMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/LintMojoTest.java
@@ -30,7 +30,7 @@ public class LintMojoTest {
 		mojo.setChartDirectory(Paths.get(getClass().getResource("Chart.yaml").toURI()).getParent().toString());
 
 		ArgumentCaptor<String> helmCommandCaptor = ArgumentCaptor.forClass(String.class);
-		doNothing().when(mojo).callCli(helmCommandCaptor.capture(), anyString());
+		doNothing().when(mojo).helm(helmCommandCaptor.capture(), anyString());
 		doReturn(Paths.get("helm" + (Os.OS_FAMILY == Os.FAMILY_WINDOWS ? ".exe" : ""))).when(mojo)
 				.getHelmExecuteablePath();
 


### PR DESCRIPTION
Since debug, registry-config, repository-cache & repository-config (see https://helm.sh/docs/helm/helm/#options) are global options i've added these to the abstract class.

I've removed 2 testcases that are tested in invoker tests as well.
Maybe the Helm calls should be wrapped in Helm CLI class later.