### PR TITLE
Refactor tests, capture commands at `Runtime.getRuntime().exec(...)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
+			<artifactId>mockito-inline</artifactId>
 			<version>${version.org.mockito}</version>
 			<scope>test</scope>
 		</dependency>

--- a/src/test/java/io/kokuwa/maven/helm/InitMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/InitMojoTest.java
@@ -79,7 +79,6 @@ public class InitMojoTest extends AbstractMojoTest {
 
 	@DisplayName("executeable: local")
 	@Test
-	@DisabledOnOs(OS.WINDOWS)
 	void localHelm(InitMojo mojo) {
 		mojo.setUseLocalHelmBinary(true);
 		mojo.setHelmVersion(null);
@@ -101,6 +100,7 @@ public class InitMojoTest extends AbstractMojoTest {
 	}
 
 	@DisplayName("executable: download with url")
+	@DisabledOnOs(OS.WINDOWS)
 	@Test
 	void downloadHelmWithUrl(InitMojo mojo) throws IOException {
 		Path helmExecutableDirectory = Files.createTempDirectory("helm-maven-plugin-test");


### PR DESCRIPTION
... instead of internal method