### PR TITLE
Fix handling of `helm:template` with `additionalArguments`, fix #260

### DIFF
--- a/src/it/template-with-additional-arguments/invoker.properties
+++ b/src/it/template-with-additional-arguments/invoker.properties
@@ -1,0 +1,1 @@
+invoker.os.family = linux, windows

--- a/src/it/template-with-additional-arguments/pom.xml
+++ b/src/it/template-with-additional-arguments/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@-it</artifactId>
+		<version>LOCAL-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>@project.artifactId@-path-with-spaces</artifactId>
+	<packaging>pom</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.kokuwa.maven</groupId>
+				<artifactId>helm-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>template</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<autoDetectLocalHelmBinary>false</autoDetectLocalHelmBinary>
+					<useLocalHelmBinary>true</useLocalHelmBinary>
+					<helmExecutableDirectory>${project.basedir}/..</helmExecutableDirectory>
+					<addDefaultRepo>false</addDefaultRepo>
+					<chartDirectory>${project.basedir}/src/main/helm</chartDirectory>
+					<chartVersion>1.0.0</chartVersion>
+					<additionalArguments>--output-dir ${project.build.directory}/custom-helm-output</additionalArguments>
+					<skipTemplate>false</skipTemplate>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/template-with-additional-arguments/postbuild.bsh
+++ b/src/it/template-with-additional-arguments/postbuild.bsh
@@ -1,0 +1,8 @@
+// verify folder created
+
+boolean outputDirCreated = new java.io.File(basedir, "target/custom-helm-output").isDirectory();
+boolean warningLogged = org.codehaus.plexus.util.FileUtils
+	.fileRead(basedir + "/build.log")
+	.contains("[WARNING] NOTE: <additionalArguments> option will be removed in future major release.");
+System.out.println("Warning logged: " + warningLogged);
+return outputDirCreated && warningLogged;

--- a/src/it/template-with-additional-arguments/prebuild.bsh
+++ b/src/it/template-with-additional-arguments/prebuild.bsh
@@ -1,0 +1,3 @@
+// verify folder does not exists
+
+return !new java.io.File(basedir, "target/custom-helm-output").isDirectory()

--- a/src/it/template-with-additional-arguments/src/main/helm/Chart.yaml
+++ b/src/it/template-with-additional-arguments/src/main/helm/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: app
+version: 0.0.1

--- a/src/it/template-with-additional-arguments/src/main/helm/templates/service.yaml
+++ b/src/it/template-with-additional-arguments/src/main/helm/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: service

--- a/src/main/java/io/kokuwa/maven/helm/TemplateMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/TemplateMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.util.StringUtils;
 
 import lombok.Setter;
 
@@ -60,8 +61,17 @@ public class TemplateMojo extends AbstractHelmWithValueOverrideMojo {
 		for (Path chartDirectory : getChartDirectories()) {
 			getLog().info(String.format("\n\nPerform template for chart %s...", chartDirectory));
 			helm()
-					.arguments(action, chartDirectory, additionalArguments)
+					.arguments(action, chartDirectory)
+					.arguments(getArguments())
 					.execute("There are test failures");
 		}
+	}
+
+	private Object[] getArguments() {
+		if (StringUtils.isEmpty(additionalArguments)) {
+			return new Object[0];
+		}
+		getLog().warn("NOTE: <additionalArguments> option will be removed in future major release.");
+		return additionalArguments.split(" ");
 	}
 }


### PR DESCRIPTION
Problem was the `Runtime.getRuntime().exec(String[])` switch, `additionalArguments` must be splitted