### PR TITLE
Overwrite local helm dependencies for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,10 @@ Parameter | Type | User Property | Required | Description
 `<templateGenerateName>` | boolean | helm.template.generate-name | false | Generate the name (and omit the NAME parameter).
 `<caFile>` | boolean | helm.push.caFile | false | Verify certificates of HTTPS-enabled servers using this CA bundle.
 `<insecure>` | boolean | helm.push.insecure | false | Skip tls certificate checks for the chart upload. Also known as `helm push --insecure-skip-tls-verify`
-`<fallbackBinaryDownload>` | boolean | helm.fallbackBinaryDownload | Controls whether a download should occur when local helm binary is not found. This property has no effect unless `<useLocalHelmBinary>` is set to `true`.
+`<fallbackBinaryDownload>` | boolean | helm.fallbackBinaryDownload | false | Controls whether a download should occur when local helm binary is not found. This property has no effect unless `<useLocalHelmBinary>` is set to `true`.
+`<overwriteLocalDependencies>` | boolean | helm.overwriteLocalDependencies | false | Controls whether a local path chart should be used for a chart dependency. When set to `true`, chart dependencies on a local path chart will be overwritten with the respective properties set by `overwriteDependencyVersion` and `overwriteDependencyRepository`. This is helpful for deploying charts with intra repository dependencies, while still being able to use local path dependencies for development builds. Example usage: for development use `mvn clean install` and for deployment use `mvn clean deploy -Dhelm.overwriteLocalDependencies=true`
+`overwriteDependencyVersion>` | string | helm.overwriteDependencyVersion | false |  Value used to overwrite a local path chart's version within a chart's dependencies. The property `overwriteLocalDependencies` must be set to `true` for this to apply.
+`overwriteDependencyRepository>` | string | helm.overwriteDependencyRepository | false | Value used to overwrite a local path chart's repository within a chart's dependencies. The property `overwriteLocalDependencies` must be set to `true` for this to apply.
 
 ## Packaging with the Helm Lifecycle
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,11 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${version.com.fasterxml.jackson}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+			<version>${version.com.fasterxml.jackson}</version>
+		</dependency>
 
 		<!-- test -->
 		<dependency>

--- a/src/it/dependency-with-overwrite/invoker.properties
+++ b/src/it/dependency-with-overwrite/invoker.properties
@@ -1,0 +1,1 @@
+invoker.os.family = linux, windows

--- a/src/it/dependency-with-overwrite/pom.xml
+++ b/src/it/dependency-with-overwrite/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@-it</artifactId>
+		<version>LOCAL-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>@project.artifactId@-path-with-spaces</artifactId>
+	<packaging>helm</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.kokuwa.maven</groupId>
+				<artifactId>helm-maven-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<autoDetectLocalHelmBinary>false</autoDetectLocalHelmBinary>
+					<useLocalHelmBinary>true</useLocalHelmBinary>
+					<helmExecutableDirectory>${project.basedir}/..</helmExecutableDirectory>
+					<helmExtraRepos>
+						<helmExtraRepo>
+							<name>kokuwaio</name>
+							<url>https://kokuwaio.github.io/helm-charts</url>
+						</helmExtraRepo>
+					</helmExtraRepos>
+					<addDefaultRepo>false</addDefaultRepo>
+					<chartDirectory>${project.basedir}/src/main/helm</chartDirectory>
+					<chartVersion>1.0.0</chartVersion>
+					<overwriteLocalDependencies>true</overwriteLocalDependencies>
+					<overwriteDependencyVersion>5.0.0</overwriteDependencyVersion>
+                    <overwriteDependencyRepository>"@kokuwaio"</overwriteDependencyRepository>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/dependency-with-overwrite/src/main/helm/Chart.yaml
+++ b/src/it/dependency-with-overwrite/src/main/helm/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: visual-regression-tracker
+    version: 2.0.1
+    repository: "@kokuwaio"
+  - name: mysqldump
+    version: 0.0.1
+    repository: file://test/path/
+  - name: fluentd-elasticsearch
+    version: 13.10.0
+    repository: "@kokuwaio"

--- a/src/main/java/io/kokuwa/maven/helm/DependencyBuildMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/DependencyBuildMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import io.kokuwa.maven.helm.util.DependencyOverwriter;
 import lombok.Setter;
 
 /**
@@ -28,6 +29,38 @@ public class DependencyBuildMojo extends AbstractHelmMojo {
 	@Parameter(property = "helm.dependency-build.skip", defaultValue = "false")
 	private boolean skipDependencyBuild;
 
+	/**
+	 * Controls whether a local path chart should be used for a chart dependency. When set to <code>true</code>,
+	 * chart dependencies on a local path chart will be overwritten with the respective properties set by
+	 * "helm.overwriteDependencyVersion" and "helm.overwriteDependencyRepository". This is helpful for deploying charts 
+	 * with intra repository dependencies, while still being able to use local path dependencies for development builds.
+	 *
+	 * Example usage:
+	 * 	For development: mvn clean install
+	 * 	For deployment: mvn clean deploy -Dhelm.overwriteLocalDependencies=true
+	 * @since 6.9.1
+	 */
+	@Parameter(property = "helm.overwriteLocalDependencies", defaultValue = "false")
+	private boolean overwriteLocalDependencies;
+
+	/**
+	 * Value used to overwrite a local path chart's version within a chart's dependencies. The property 
+	 * "helm.overwriteLocalDependencies" must be set to <code>true</code> for this to apply.
+	 *
+	 * @since 6.9.1
+	 */
+	@Parameter(property = "helm.overwriteDependencyVersion")
+	private String overwriteDependencyVersion;
+
+	/**
+	 * Value used to overwrite a local path chart's repository within a chart's dependencies. The property 
+	 * "helm.overwriteLocalDependencies" must be set to <code>true</code> for this to apply.
+	 *
+	 * @since 6.9.1
+	 */
+	@Parameter(property = "helm.overwriteDependencyRepository")
+	private String overwriteDependencyRepository;
+
 	@Override
 	public void execute() throws MojoExecutionException {
 
@@ -37,6 +70,12 @@ public class DependencyBuildMojo extends AbstractHelmMojo {
 		}
 
 		for (Path chartDirectory : getChartDirectories()) {
+			if (overwriteLocalDependencies) {
+				DependencyOverwriter dependencyOverwriter = 
+					new DependencyOverwriter(overwriteDependencyRepository, overwriteDependencyVersion, getLog());
+				dependencyOverwriter.execute(chartDirectory);
+			}
+
 			getLog().info("Build chart dependencies for " + chartDirectory + " ...");
 			helm()
 					.arguments("dependency", "build", chartDirectory)

--- a/src/main/java/io/kokuwa/maven/helm/pojo/Dependencies.java
+++ b/src/main/java/io/kokuwa/maven/helm/pojo/Dependencies.java
@@ -1,0 +1,28 @@
+package io.kokuwa.maven.helm.pojo;
+
+import java.util.ArrayList;
+
+import lombok.Data;
+
+/**
+ * POJO for list of Chart.yaml dependencies
+ *
+ * @since 6.9.1
+ */
+@Data
+public class Dependencies {
+	private ArrayList<Dependency> dependencies;
+
+	@Data
+	public static class Dependency {
+		private String name;
+		private String version;
+		private String repository;
+
+		/**
+		 * Determines whether the repository/version will be updated 
+		 * for a given dependency.
+		 */
+		private boolean overwrite = false;		
+	}
+}

--- a/src/main/java/io/kokuwa/maven/helm/util/DependencyOverwriter.java
+++ b/src/main/java/io/kokuwa/maven/helm/util/DependencyOverwriter.java
@@ -1,0 +1,240 @@
+package io.kokuwa.maven.helm.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import io.kokuwa.maven.helm.pojo.Dependencies;
+import io.kokuwa.maven.helm.pojo.Dependencies.Dependency;
+
+/**
+ * Utility class for overwriting a local path charts within a chart's dependencies.
+ *
+ * @since 6.9.1
+ */
+public class DependencyOverwriter {
+
+	private File writeDirectory;
+
+	private String overwriteRepository;
+
+	private String overwriteVersion;
+
+	private Log log;
+
+	/**
+	 * Constructor for setting constants
+	 * @param overwriteRepository used to overwrite a local path chart's repository
+	 * @param overwriteVersion used to overwrite a local path chart's version
+	 * @param log used to write output from the util
+	 */
+	public DependencyOverwriter(String overwriteRepository, String overwriteVersion, Log log) {
+		this.overwriteRepository = overwriteRepository;
+		this.overwriteVersion = overwriteVersion;
+		this.log = log;
+	}
+	
+	/**
+	 * Used in testing for setting a custom filePath to write the new Chart.yaml to
+	 * @param directory {@link File} directory to write the new Chart.yaml to
+	 */
+	public void setWriteDirectory(File directory) {
+		this.writeDirectory = directory;
+	}
+
+	/**
+	 * Read in the dependencies from the Chart.yaml into the {@link Dependencies} POJO
+	 * @param chartFile Chart.yaml file to read
+	 * @return {@link ArrayList}<{@link Dependency}>
+	 * @throws MojoExecutionException Unable to read Chart.yaml dependencies
+	 */
+	private ArrayList<Dependency> getDependencies(File chartFile) throws MojoExecutionException {
+		ObjectMapper yamlMapper = new YAMLMapper();
+		yamlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+		Dependencies dependencies;
+		try {
+			dependencies = yamlMapper.readValue(chartFile, Dependencies.class);
+		} catch (IOException e) {
+			throw new MojoExecutionException("Unable to read chart dependencies from " + chartFile, e);
+		}
+
+		return dependencies.getDependencies();
+	}
+
+	/**
+	 * Sets the boolean for the {@link Dependency} that need to be overwritten
+	 * @param dependencies {@Link ArrayList}<{@link Dependency}>
+	 */
+	private void updateDependencies(ArrayList<Dependency> dependencies) {
+		for (Dependency dependency : dependencies) {
+			if (dependency.getRepository() != null && dependency.getRepository().startsWith("file://")) {
+				dependency.setOverwrite(true);
+			}
+		}
+	}
+
+	/**
+	 * Overwrite the dependencies with their new values to the Chart.yaml 
+	 * @param dependencies {@link ArrayList}<{@link Dependency}>
+	 * @param chartFile Chart.yaml file to read
+	 * @param directory Directory to write the new Chart.yaml to
+	 * @throws MojoExecutionException unable to read/write Chart.yaml
+	 */
+	private void overwriteDependencies(ArrayList<Dependency> dependencies, File chartFile, Path directory) 
+		throws MojoExecutionException {
+
+		//delete the outdated Chart.lock
+		File chartLock = new File(directory.toString() + "/Chart.lock");
+		
+		if (chartLock.exists()) {
+			chartLock.delete();
+			this.log.info("Chart.lock deleted at " + directory);
+		} else {
+			this.log.info("No Chart.lock file found at " + directory);
+		}
+
+		List<String> overwrittenChart = new ArrayList<>();
+		List<String> originalChart;
+		try {
+			originalChart = Files.readAllLines(Paths.get(chartFile.toURI()), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new MojoExecutionException("Unable to read Chart.yaml at " + directory, e);
+		}
+
+		//Used for determining when a dependency has been read
+		boolean name, repository, version, isDependencies;
+		name = version = repository = isDependencies = false;
+
+		Iterator<Dependency> dependencyIterator = dependencies.iterator();
+		Dependency currentDependency = dependencyIterator.next();
+
+		for (String line : originalChart) {
+			//check for lines that need to be overwritten
+			if (isDependencies) {
+				if (line.contains("version:")) { 
+					version = true;
+					
+					//if no overwrite value is provided for the version, the original will be used
+					if (currentDependency.isOverwrite() && this.overwriteVersion != null 
+						&& !this.overwriteVersion.isEmpty()) {
+						this.log.info("Overwriting dependency '" + currentDependency.getName() + 
+							"' with new version:");
+						this.log.info("\tOld Value:");
+						this.log.info(line);
+
+						//preserve any characters/spacing that may appear around the attribute
+						line = line.replace(currentDependency.getVersion(), this.overwriteVersion);
+
+						this.log.info("\tNew Value:");
+						this.log.info(line);
+					}
+				} else if (line.contains("repository:")) {
+					repository = true;
+
+					if (currentDependency.isOverwrite()) {
+						this.log.info("Overwriting dependency '" + currentDependency.getName() + 
+							"' with new repository:");
+						this.log.info("\tOld Value:");
+						this.log.info(line);
+
+						//preserve any characters/spacing that may appear around the attribute
+						line = line.replace(currentDependency.getRepository(), this.overwriteRepository);
+
+						this.log.info("\tNew Value:");
+						this.log.info(line);
+					}
+				} else if (line.contains("name:")) { 
+						name = true;
+				}
+
+				//Repository is not a required field so could be null
+				if (currentDependency.getRepository() == null) {
+					repository = true;
+				}
+
+				//check if the current dependency has been read completely
+				if (name && version && repository) {
+					name = version = repository = false;
+
+					//check if there are any remaining dependencies
+					if (dependencyIterator.hasNext()) {
+						currentDependency = dependencyIterator.next();
+					} else {
+						isDependencies = false;
+					}
+				}
+			} 
+			//determines whether currently in the dependencies section of the yaml
+			else if (line.contains("dependencies:")) {
+				isDependencies = true;
+			}
+
+			overwrittenChart.add(line);
+		}
+
+		//overwrite the existing Chart.yaml with the new values
+		try {
+			File newFile;
+			if (this.writeDirectory != null) {
+				newFile = new File(this.writeDirectory.toString() + "/Chart.yaml");
+			} else {
+				newFile = new File(directory.toString() + "/Chart.yaml");
+			}
+			Files.write(Paths.get(newFile.toURI()), overwrittenChart, StandardCharsets.UTF_8);
+			this.log.info("Overwriting successful for " + newFile);
+		} catch (IOException e) {
+			throw new MojoExecutionException("Unable to overwrite Chart.yaml at " + directory, e);
+		}
+	}
+
+	/**
+	 * Utility class for overwriting local chart dependencies when making use of helm.overwriteLocalDependencies
+	 * @param directory {@link Path} directory to overwrite the Chart.yaml
+	 * @throws MojoExecutionException Must set a value for helm.overwriteDependencyRepository
+	 */
+	public void execute(Path directory) throws MojoExecutionException {
+		if (this.overwriteRepository == null) {
+			throw new MojoExecutionException("Null value for 'overwriteDependencyRepository' is " +
+			"not allowed when using 'overwriteLocalDependencies'. See the README for more details.");
+		} else {
+			this.log.info("Overwriting dependencies that contain local path charts...");
+		}
+
+		File chartYamlFile = new File(directory.toString() + "/Chart.yaml");
+
+		if (chartYamlFile.exists()) {
+			ArrayList<Dependency> dependencies = this.getDependencies(chartYamlFile);
+
+			//check if the chart has any dependencies 
+			if (dependencies != null && dependencies.size() > 0) {
+				this.updateDependencies(dependencies);
+
+				//check if any dependencies need to be overwritten
+				if (dependencies.stream().anyMatch(dependency -> dependency.isOverwrite())) {
+					this.overwriteDependencies(dependencies, chartYamlFile, directory);
+				} else {
+					this.log.info("No dependencies to update for " + chartYamlFile);
+				}
+			}
+			else {
+				this.log.info("No dependencies found for " + chartYamlFile);
+			}
+		} else {
+			this.log.warn("No Charts detected - no Chart.yaml files found below " + directory);
+		}
+	}
+}

--- a/src/test/java/io/kokuwa/maven/helm/junit/DependencyOverwriterTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/junit/DependencyOverwriterTest.java
@@ -1,0 +1,210 @@
+package io.kokuwa.maven.helm.junit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.jupiter.api.Test;
+
+import io.kokuwa.maven.helm.util.DependencyOverwriter;
+
+/**
+ * Test functionality of utility class {@link DependencyOverwriter} against
+ * many different scenarios
+ */
+public class DependencyOverwriterTest {
+
+	private String overwriteDependencyRepository = "https://fake.repo/";
+
+	private String overwriteDependencyVersion = "1.0.0";
+
+	private Log logger = new SystemStreamLog();
+
+	private String testResourcesPath = "src/test/resources/dependency-overwrite/";
+
+	/**
+	 * Tests overwriting in a chart with one dependency to overwrite
+	 */
+	@Test
+	public void testBasicOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("basic", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/BasicTest.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing a single dependency");
+	}
+
+	/**
+	 * Tests overwriting in a chart with multiple dependencies to overwrite
+	 */
+	@Test
+	public void testMultiOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("multi", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/MultiTest.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing multiple dependencies");
+	}
+
+	/**
+	 * Tests overwriting in a chart with no dependencies
+	 */
+	@Test
+	public void testNoOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("none", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+
+		//verify no chart is generated since there are no dependencies to override
+		assertFalse(overwrittenChart.isFile(), "Chart.yaml should not have been overwritten");
+	}
+
+	/**
+	 * Tests overwriting in a chart with a dependency with a null repository
+	 */
+	@Test
+	public void testNullRepoOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("null/repo", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/NullRepoTest.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing a dependency without a repository");
+	}
+
+	/**
+	 * Tests overwriting in a chart when a version to overwrite is not provided
+	 */
+	@Test
+	public void testNullVersionOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("null/version", this.overwriteDependencyRepository, null);
+		File validationChart = new File(testResourcesPath + "validation/NullVersionTest.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Dependency version should remain the same when overwrite version is null");
+	}
+
+	/**
+	 * Tests overwriting in a chart with a out of order dependencies
+	 */
+	@Test
+	public void testOutOfOrderOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("out-of-order", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/OutOfOrderTest.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing out of order dependencies");
+	}
+
+	/**
+	 * Tests overwriting in a chart with dependencies with extra attributes
+	 */
+	@Test
+	public void testExtraDependencyAttributeOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("extra/dependency-attribute", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/ExtraDependencyAttribute.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing dependencies with extra attributes");
+	}
+
+	/**
+	 * Tests overwriting in a chart with extra chart attributes after the dependencies
+	 */
+	@Test
+	public void testExtraChartAttributeOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("extra/chart-attribute", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/ExtraChartAttribute.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing extra chart attributes");
+	}
+
+	/**
+	 * Tests overwriting in a chart with dependencies with extra spacing
+	 */
+	@Test
+	public void testExtraSpaceOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("extra/space", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/ExtraSpace.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing dependencies with extra spacing");
+	}
+
+	/**
+	 * Tests overwriting in a chart with dependencies with extra text/comments
+	 */
+	@Test
+	public void testExtraTextOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("extra/text", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/ExtraText.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing dependencies with extra text/comments");
+	}
+
+	/**
+	 * Tests overwriting in a chart with dependencies with extra new lines
+	 */
+	@Test
+	public void testExtraLinesOverwrite() throws MojoExecutionException, IOException {
+		File overwrittenChart = this.overWriteChart("extra/line", this.overwriteDependencyRepository, 
+			this.overwriteDependencyVersion);
+		File validationChart = new File(testResourcesPath + "validation/ExtraLine.yaml");
+
+		//verify the charts are the same
+		assertTrue(FileUtils.contentEquals(overwrittenChart, validationChart),
+			"Failed to overwrite Chart.yaml containing dependencies with extra new lines");
+	}
+
+	/**
+	 * Helper function for executing {@link DependencyOverwriter}
+	 * @param testName Used to find the Chart.yaml to overwrite
+	 * @param overwriteRepository repo used to overwrite
+	 * @param overwriteVersion version to overwrite
+	 * @return {@link File} that was overwritten
+	 * @throws MojoExecutionException
+	 */
+	private File overWriteChart(String testName, String overwriteRepository, String overwriteVersion) 
+		throws MojoExecutionException {
+		//read in the chart to be overwritten
+		File chartDirectory = new File(testResourcesPath + "to-overwrite/" + testName + "/");
+
+		//set the output directory for the overwritten chart
+		File writeDirectory = new File(testResourcesPath + "to-overwrite/" + testName + "/target/");
+		writeDirectory.mkdirs();
+
+		//execute the overwriter utility
+		DependencyOverwriter dependencyOverwriter = new DependencyOverwriter(overwriteRepository,
+			overwriteVersion, this.logger);
+
+		dependencyOverwriter.setWriteDirectory(writeDirectory);
+		dependencyOverwriter.execute(Paths.get(chartDirectory.getAbsolutePath()));
+
+		//get the newly overwritten chart and the validation chart
+		return new File(writeDirectory.toString() + "/Chart.yaml");
+	}
+}

--- a/src/test/resources/dependency-overwrite/to-overwrite/basic/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/basic/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 0.0.1
+    repository: file://test/path/

--- a/src/test/resources/dependency-overwrite/to-overwrite/extra/chart-attribute/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/extra/chart-attribute/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 0.0.1
+    repository: file://test/path/
+  - name: testDependency2
+    version: 3.1.1
+    repository: https://fake.repo/
+
+# Test comment
+appVersion: 1.0.0
+sources:
+  - https://test.source

--- a/src/test/resources/dependency-overwrite/to-overwrite/extra/dependency-attribute/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/extra/dependency-attribute/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 0.0.1
+    repository: file://test/path/
+    condition: test
+    tags:
+      - test1
+      - test2
+  - name: testDependency2
+    version: 5.0.1
+    repository: https://fake.repo/
+    import-values:
+      - test1
+      - child: default.data
+        parent: myimports
+    alias: alias1

--- a/src/test/resources/dependency-overwrite/to-overwrite/extra/line/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/extra/line/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+    -
+        name: testDependency1
+        version: 0.0.1
+        repository: file://test/path/
+    -
+        name: testDependency2
+        version: 3.1.1
+        repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/to-overwrite/extra/space/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/extra/space/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+    - name: testDependency1
+      version: 0.0.1
+      repository: file://test/path/
+    - name: testDependency2
+      version: 3.1.1
+      repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/to-overwrite/extra/text/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/extra/text/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+# test comment
+dependencies:
+  - name: testDependency1  # test comment
+    version: 0.0.1  # test comment
+    repository: file://test/path/  # test comment
+  - name: testDependency2  # test comment
+    version: 3.1.1  # test comment
+    repository: https://fake.repo/  # test comment
+# test comment

--- a/src/test/resources/dependency-overwrite/to-overwrite/multi/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/multi/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 0.0.1
+    repository: file://test/path/
+  - name: testDependency2
+    version: 3.1.1
+    repository: https://fake.repo/
+  - name: testDependency3
+    version: 0.0.1
+    repository: file://test/path/
+  - name: testDependency4
+    version: 5.4.5
+    repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/to-overwrite/none/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/none/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: app
+version: 0.0.1

--- a/src/test/resources/dependency-overwrite/to-overwrite/null/repo/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/null/repo/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 5.0.1
+  - name: testDependency2
+    version: 0.0.1
+    repository: file://test/path/

--- a/src/test/resources/dependency-overwrite/to-overwrite/null/version/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/null/version/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 5.0.1
+    repository: https://fake.repo/
+  - name: testDependency2
+    version: 0.0.1
+    repository: file://test/path/

--- a/src/test/resources/dependency-overwrite/to-overwrite/out-of-order/Chart.yaml
+++ b/src/test/resources/dependency-overwrite/to-overwrite/out-of-order/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - repository: file://test/path/
+    name: testDependency1
+    version: 0.0.1
+  - version: 3.1.1
+    name: testDependency2
+    repository: https://fake.repo/
+  - name: testDependency3
+    version: 0.0.1
+    repository: file://test/path/
+  - repository: https://fake.repo/
+    version: 5.4.5
+    name: testDependency4

--- a/src/test/resources/dependency-overwrite/validation/BasicTest.yaml
+++ b/src/test/resources/dependency-overwrite/validation/BasicTest.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 1.0.0
+    repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/validation/ExtraChartAttribute.yaml
+++ b/src/test/resources/dependency-overwrite/validation/ExtraChartAttribute.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 1.0.0
+    repository: https://fake.repo/
+  - name: testDependency2
+    version: 3.1.1
+    repository: https://fake.repo/
+
+# Test comment
+appVersion: 1.0.0
+sources:
+  - https://test.source

--- a/src/test/resources/dependency-overwrite/validation/ExtraDependencyAttribute.yaml
+++ b/src/test/resources/dependency-overwrite/validation/ExtraDependencyAttribute.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 1.0.0
+    repository: https://fake.repo/
+    condition: test
+    tags:
+      - test1
+      - test2
+  - name: testDependency2
+    version: 5.0.1
+    repository: https://fake.repo/
+    import-values:
+      - test1
+      - child: default.data
+        parent: myimports
+    alias: alias1

--- a/src/test/resources/dependency-overwrite/validation/ExtraLine.yaml
+++ b/src/test/resources/dependency-overwrite/validation/ExtraLine.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+    -
+        name: testDependency1
+        version: 1.0.0
+        repository: https://fake.repo/
+    -
+        name: testDependency2
+        version: 3.1.1
+        repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/validation/ExtraSpace.yaml
+++ b/src/test/resources/dependency-overwrite/validation/ExtraSpace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+    - name: testDependency1
+      version: 1.0.0
+      repository: https://fake.repo/
+    - name: testDependency2
+      version: 3.1.1
+      repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/validation/ExtraText.yaml
+++ b/src/test/resources/dependency-overwrite/validation/ExtraText.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+# test comment
+dependencies:
+  - name: testDependency1  # test comment
+    version: 1.0.0  # test comment
+    repository: https://fake.repo/  # test comment
+  - name: testDependency2  # test comment
+    version: 3.1.1  # test comment
+    repository: https://fake.repo/  # test comment
+# test comment

--- a/src/test/resources/dependency-overwrite/validation/MultiTest.yaml
+++ b/src/test/resources/dependency-overwrite/validation/MultiTest.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 1.0.0
+    repository: https://fake.repo/
+  - name: testDependency2
+    version: 3.1.1
+    repository: https://fake.repo/
+  - name: testDependency3
+    version: 1.0.0
+    repository: https://fake.repo/
+  - name: testDependency4
+    version: 5.4.5
+    repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/validation/NullRepoTest.yaml
+++ b/src/test/resources/dependency-overwrite/validation/NullRepoTest.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 5.0.1
+  - name: testDependency2
+    version: 1.0.0
+    repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/validation/NullVersionTest.yaml
+++ b/src/test/resources/dependency-overwrite/validation/NullVersionTest.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - name: testDependency1
+    version: 5.0.1
+    repository: https://fake.repo/
+  - name: testDependency2
+    version: 0.0.1
+    repository: https://fake.repo/

--- a/src/test/resources/dependency-overwrite/validation/OutOfOrderTest.yaml
+++ b/src/test/resources/dependency-overwrite/validation/OutOfOrderTest.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app
+version: 0.0.1
+
+dependencies:
+  - repository: https://fake.repo/
+    name: testDependency1
+    version: 1.0.0
+  - version: 3.1.1
+    name: testDependency2
+    repository: https://fake.repo/
+  - name: testDependency3
+    version: 1.0.0
+    repository: https://fake.repo/
+  - repository: https://fake.repo/
+    version: 5.4.5
+    name: testDependency4


### PR DESCRIPTION
Additional functionality for controlling whether a local path chart should be used for a chart dependency. When setting the new `helm.overwriteLocalDependencies` to `true`, chart dependencies on a local path chart will be overwritten with the respective properties set by `helm.overwriteDependencyVersion` and `helm.overwriteDependencyRepository`. This is helpful for deploying charts with intra repository dependencies, while still being able to use local path dependencies for development builds.

 Example usage:
   For development, this allows you to build with local dependencies like `repository: file://test/path/` within your `Chart.yaml` with:
 	`mvn clean install`

   For deployment, the local dependencies can be updated with remote repo they will live at. This way you are not deploying charts with local dependencies.
 	`mvn clean deploy -Dhelm.overwriteLocalDependencies=true -Dhelm.overwriteDependencyVersion=1.0.0 -Dhelm.overwriteDependencyRepository=https://your.remote.repo/`