### PR TITLE
Add flag to skip TLS checks against the Kubernetes API server's certi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Parameter | Type | User Property | Required | Description
 `<values>` | [ValueOverride](./src/main/java/io/kokuwa/maven/helm/pojo/ValueOverride.java) | | false | override some values for linting with helm.values.overrides (--set option), helm.values.stringOverrides (--set-string option), helm.values.fileOverrides (--set-file option) and last but not least helm.values.yamlFile (--values option)
 `<namespace>` | string | helm.namespace | false | namespace scope for helm command
 `<kubeApiServer>` | string | helm.kubeApiServer | false | the address and the port for the Kubernetes API server
+`<kubeInsecure>` | string | helm.kubeInsecure | false | Skip tls certificate checks for the operation. Also known as `helm --kube-insecure-skip-tls-verify`.
 `<kubeAsUser>` | string | helm.kubeAsUser | false | username to impersonate for the operation
 `<kubeAsGroup>` | string | helm.kubeAsGroup | false | group to impersonate for the operation, this flag can be repeated to specify multiple groups
 `<kubeToken>` | string | helm.kubeToken | false | bearer token used for authentication

--- a/src/main/java/io/kokuwa/maven/helm/AbstractHelmMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/AbstractHelmMojo.java
@@ -230,6 +230,14 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 	private String kubeApiServer;
 
 	/**
+	 * Skip tls certificate checks for the operation. Also known as `helm --kube-insecure-skip-tls-verify`.
+	 *
+	 * @since 6.10.0
+	 */
+	@Parameter(property = "helm.kubeInsecure")
+	private boolean kubeInsecure;
+
+	/**
 	 * Username to impersonate for the operation.
 	 *
 	 * @since 6.4.0
@@ -315,6 +323,7 @@ public abstract class AbstractHelmMojo extends AbstractMojo {
 				.flag("kube-as-group", kubeAsUser)
 				.flag("kube-as-user", kubeAsGroup)
 				.flag("kube-ca-file", kubeCaFile)
+				.flag("kube-insecure-skip-tls-verify", kubeInsecure)
 				.flag("kube-token", kubeToken)
 				.flag("namespace", namespace)
 				.flag("registry-config", registryConfig)


### PR DESCRIPTION
Sometimes working with Kubernetes we want to skip TLS verification. 
Helm allows us to do it providing the flag `--kube-insecure-skip-tls-verify`.
I've added a boolean configuration property `kubeInsecure` which helps to skip TLS certificate checks for Helm operations such as `upgrade`, `install` and so on.
This small improvement simplifies the usage of the plugin in a CICD environment. 