### PR TITLE
Add flags to install and upgrade Helm releases consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,9 @@ Parameter | Type | User Property | Required | Description
 `<kubeToken>` | string | helm.kubeToken | false | bearer token used for authentication
 `<releaseName>` | string | helm.releaseName | false | Name of the release for upgrade goal
 `<installAtomic>` | boolean | helm.install.atomic | false | Set this to `true` to delete the installation on failure.
-`<installTimeout>` | boolean | helm.upgrade.imeout | false | Time to wait for any individual Kubernetes operation during install process. The default is 5 minutes if `installAtomic` is set to `true`.
+`<installTimeout>` | boolean | helm.upgrade.imeout | false | Time in seconds to wait for any individual Kubernetes operation during install process. The default is 300 seconds if `installAtomic` is set to `true`.
 `<upgradeAtomic>` | boolean | helm.upgrade.atomic | false | Set this to `true` to rollback changes made in case of failed upgrade.
-`<upgradeTimeout>` | boolean | helm.upgrade.imeout | false | Time to wait for any individual Kubernetes operation during upgrade process. The default is 5 minutes if `upgradeTimeout` is set to `true`.
+`<upgradeTimeout>` | boolean | helm.upgrade.imeout | false | Time in seconds to wait for any individual Kubernetes operation during upgrade process. The default is 300 seconds if `upgradeTimeout` is set to `true`.
 `<upgradeDryRun>` | boolean | helm.upgrade.dryRun | false | Run upgrade goal only in dry run mode
 `<templateOutputDir>` | file | helm.template.output-dir | false | Writes the executed templates to files in output-dir instead of stdout.
 `<templateGenerateName>` | boolean | helm.template.generate-name | false | Generate the name (and omit the NAME parameter).

--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ Parameter | Type | User Property | Required | Description
 `<kubeAsGroup>` | string | helm.kubeAsGroup | false | group to impersonate for the operation, this flag can be repeated to specify multiple groups
 `<kubeToken>` | string | helm.kubeToken | false | bearer token used for authentication
 `<releaseName>` | string | helm.releaseName | false | Name of the release for upgrade goal
+`<installAtomic>` | boolean | helm.install.atomic | false | Set this to `true` to delete the installation on failure.
+`<installTimeout>` | boolean | helm.upgrade.imeout | false | Time to wait for any individual Kubernetes operation during install process. The default is 5 minutes if `installAtomic` is set to `true`.
+`<upgradeAtomic>` | boolean | helm.upgrade.atomic | false | Set this to `true` to rollback changes made in case of failed upgrade.
+`<upgradeTimeout>` | boolean | helm.upgrade.imeout | false | Time to wait for any individual Kubernetes operation during upgrade process. The default is 5 minutes if `upgradeTimeout` is set to `true`.
 `<upgradeDryRun>` | boolean | helm.upgrade.dryRun | false | Run upgrade goal only in dry run mode
 `<templateOutputDir>` | file | helm.template.output-dir | false | Writes the executed templates to files in output-dir instead of stdout.
 `<templateGenerateName>` | boolean | helm.template.generate-name | false | Generate the name (and omit the NAME parameter).

--- a/src/main/java/io/kokuwa/maven/helm/InstallMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/InstallMojo.java
@@ -32,6 +32,22 @@ public class InstallMojo extends AbstractHelmWithValueOverrideMojo {
 	private String action;
 
 	/**
+	 * Set this to <code>true</code> to delete the installation on failure.
+	 *
+	 * @since 6.10.0
+	 */
+	@Parameter(property = "helm.install.atomic")
+	private boolean installAtomic;
+
+	/**
+	 * Time to wait for any individual Kubernetes operation.
+	 *
+	 * @since 6.10.0
+	 */
+	@Parameter(property = "helm.install.timeout")
+	private String installTimeout;
+
+	/**
 	 * Set this to <code>true</code> to skip invoking install goal.
 	 *
 	 * @since 5.10
@@ -48,9 +64,13 @@ public class InstallMojo extends AbstractHelmWithValueOverrideMojo {
 		}
 
 		for (Path chartDirectory : getChartDirectories()) {
-			getLog().info(String.format("\n\nPerform install for chart %s...", chartDirectory));
+			getLog().info(String.format("\n\nPerform install for chart %s...", chartDirectory) +
+					(installAtomic ? " with atomic" : "") +
+					(installTimeout != null ? String.format(" with timeout %s", installTimeout) : ""));
 			helm()
 					.arguments(action, chartDirectory.getFileName().toString(), chartDirectory)
+					.flag("atomic", installAtomic)
+					.flag("timeout", installTimeout)
 					.execute("Failed to deploy helm chart");
 		}
 	}

--- a/src/main/java/io/kokuwa/maven/helm/InstallMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/InstallMojo.java
@@ -40,12 +40,12 @@ public class InstallMojo extends AbstractHelmWithValueOverrideMojo {
 	private boolean installAtomic;
 
 	/**
-	 * Time to wait for any individual Kubernetes operation.
+	 * Time in seconds to wait for any individual Kubernetes operation.
 	 *
 	 * @since 6.10.0
 	 */
 	@Parameter(property = "helm.install.timeout")
-	private String installTimeout;
+	private int installTimeout;
 
 	/**
 	 * Set this to <code>true</code> to skip invoking install goal.
@@ -66,11 +66,11 @@ public class InstallMojo extends AbstractHelmWithValueOverrideMojo {
 		for (Path chartDirectory : getChartDirectories()) {
 			getLog().info(String.format("\n\nPerform install for chart %s...", chartDirectory) +
 					(installAtomic ? " with atomic" : "") +
-					(installTimeout != null ? String.format(" with timeout %s", installTimeout) : ""));
+					(installTimeout > 0 ? String.format(" timeout %s", installTimeout) : ""));
 			helm()
 					.arguments(action, chartDirectory.getFileName().toString(), chartDirectory)
 					.flag("atomic", installAtomic)
-					.flag("timeout", installTimeout)
+					.flag("timeout", installTimeout > 0 ? installTimeout + "s" : null)
 					.execute("Failed to deploy helm chart");
 		}
 	}

--- a/src/main/java/io/kokuwa/maven/helm/UpgradeMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/UpgradeMojo.java
@@ -36,12 +36,12 @@ public class UpgradeMojo extends AbstractHelmWithValueOverrideMojo {
 	private boolean upgradeAtomic;
 
 	/**
-	 * Time to wait for any individual Kubernetes operation.
+	 * Time in seconds to wait for any individual Kubernetes operation.
 	 *
 	 * @since 6.10.0
 	 */
 	@Parameter(property = "helm.upgrade.timeout")
-	private String upgradeTimeout;
+	private int upgradeTimeout;
 
 	/**
 	 * Upgrade with install parameter.
@@ -79,7 +79,7 @@ public class UpgradeMojo extends AbstractHelmWithValueOverrideMojo {
 			getLog().info("Upgrading the chart " +
 					(upgradeWithInstall ? "with install " : "") +
 					(upgradeAtomic ? "with atomic " : "") +
-					(upgradeTimeout != null ? String.format("timeout %s ", upgradeTimeout) : "") +
+					(upgradeTimeout > 0 ? String.format("timeout %s ", upgradeTimeout) : "") +
 					(upgradeDryRun ? "as dry run " : "") +
 					chartDirectory);
 			helm()
@@ -87,7 +87,7 @@ public class UpgradeMojo extends AbstractHelmWithValueOverrideMojo {
 					.flag("install", upgradeWithInstall)
 					.flag("dry-run", upgradeDryRun)
 					.flag("atomic", upgradeAtomic)
-					.flag("timeout", upgradeTimeout)
+					.flag("timeout", upgradeTimeout > 0 ? upgradeTimeout + "s" : null)
 					.execute("Error occurred while upgrading the chart");
 		}
 	}

--- a/src/main/java/io/kokuwa/maven/helm/UpgradeMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/UpgradeMojo.java
@@ -28,6 +28,22 @@ public class UpgradeMojo extends AbstractHelmWithValueOverrideMojo {
 	private boolean skipUpgrade;
 
 	/**
+	 * Set this to <code>true</code> to rollback changes made in case of failed upgrade.
+	 *
+	 * @since 6.10.0
+	 */
+	@Parameter(property = "helm.upgrade.atomic")
+	private boolean upgradeAtomic;
+
+	/**
+	 * Time to wait for any individual Kubernetes operation.
+	 *
+	 * @since 6.10.0
+	 */
+	@Parameter(property = "helm.upgrade.timeout")
+	private String upgradeTimeout;
+
+	/**
 	 * Upgrade with install parameter.
 	 *
 	 * @since 6.4.0
@@ -60,14 +76,18 @@ public class UpgradeMojo extends AbstractHelmWithValueOverrideMojo {
 		}
 
 		for (Path chartDirectory : getChartDirectories()) {
-			getLog().info("installing the chart " +
+			getLog().info("Upgrading the chart " +
 					(upgradeWithInstall ? "with install " : "") +
+					(upgradeAtomic ? "with atomic " : "") +
+					(upgradeTimeout != null ? String.format("timeout %s ", upgradeTimeout) : "") +
 					(upgradeDryRun ? "as dry run " : "") +
 					chartDirectory);
 			helm()
 					.arguments("upgrade", releaseName, chartDirectory)
 					.flag("install", upgradeWithInstall)
 					.flag("dry-run", upgradeDryRun)
+					.flag("atomic", upgradeAtomic)
+					.flag("timeout", upgradeTimeout)
 					.execute("Error occurred while upgrading the chart");
 		}
 	}

--- a/src/test/java/io/kokuwa/maven/helm/InstallMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/InstallMojoTest.java
@@ -38,7 +38,7 @@ public class InstallMojoTest extends AbstractMojoTest {
 	void atomicAndTimeout(InstallMojo mojo) {
 		mojo.setSkipInstall(false);
 		mojo.setInstallAtomic(true);
-		mojo.setInstallTimeout("30s");
+		mojo.setInstallTimeout(30);
 		assertHelm(mojo, "install simple src/test/resources/simple --atomic --timeout 30s");
 	}
 

--- a/src/test/java/io/kokuwa/maven/helm/InstallMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/InstallMojoTest.java
@@ -25,6 +25,23 @@ public class InstallMojoTest extends AbstractMojoTest {
 		assertHelm(mojo.setSkipInstall(true).setSkip(true));
 	}
 
+	@DisplayName("with flag atomic")
+	@Test
+	void atomic(InstallMojo mojo) {
+		mojo.setSkipInstall(false);
+		mojo.setInstallAtomic(true);
+		assertHelm(mojo, "install simple src/test/resources/simple --atomic");
+	}
+
+	@DisplayName("with flags atomic and timeout")
+	@Test
+	void atomicAndTimeout(InstallMojo mojo) {
+		mojo.setSkipInstall(false);
+		mojo.setInstallAtomic(true);
+		mojo.setInstallTimeout("30s");
+		assertHelm(mojo, "install simple src/test/resources/simple --atomic --timeout 30s");
+	}
+
 	@DisplayName("with values overrides")
 	@Test
 	void valuesFile(InstallMojo mojo) {

--- a/src/test/java/io/kokuwa/maven/helm/UpgradeMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/UpgradeMojoTest.java
@@ -50,7 +50,7 @@ public class UpgradeMojoTest extends AbstractMojoTest {
 		mojo.setReleaseName("foo");
 		mojo.setUpgradeWithInstall(false);
 		mojo.setUpgradeAtomic(true);
-		mojo.setUpgradeTimeout("30s");
+		mojo.setUpgradeTimeout(30);
 		assertHelm(mojo, "upgrade foo src/test/resources/simple --atomic --timeout 30s");
 	}
 

--- a/src/test/java/io/kokuwa/maven/helm/UpgradeMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/UpgradeMojoTest.java
@@ -33,6 +33,27 @@ public class UpgradeMojoTest extends AbstractMojoTest {
 		assertHelm(mojo, "upgrade foo src/test/resources/simple --install --dry-run");
 	}
 
+	@DisplayName("with flag atomic")
+	@Test
+	void atomic(UpgradeMojo mojo) {
+		mojo.setSkipUpgrade(false);
+		mojo.setReleaseName("foo");
+		mojo.setUpgradeWithInstall(false);
+		mojo.setUpgradeAtomic(true);
+		assertHelm(mojo, "upgrade foo src/test/resources/simple --atomic");
+	}
+
+	@DisplayName("with flags atomic and timeout")
+	@Test
+	void atomicAndTimeout(UpgradeMojo mojo) {
+		mojo.setSkipUpgrade(false);
+		mojo.setReleaseName("foo");
+		mojo.setUpgradeWithInstall(false);
+		mojo.setUpgradeAtomic(true);
+		mojo.setUpgradeTimeout("30s");
+		assertHelm(mojo, "upgrade foo src/test/resources/simple --atomic --timeout 30s");
+	}
+
 	@DisplayName("without flag install")
 	@Test
 	void install(UpgradeMojo mojo) {


### PR DESCRIPTION
When something goes wrong during a chart deployment Helm will leave it as is.
Consequently, we can get into a situation when a previous release is superseded with the new one which does not work.

Usage of the `--atomic` option with `helm install` or `helm upgrade` allows to roll back deployment to the previous version automatically if it fails.
The `--timeout` tells how long Helm should wait for the readiness of the deployment.
