### PR TITLE
feat: add skip-refresh flag to dependency-build/update goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ Parameter | Type | User Property | Required | Description
 `<skipTemplate>` | boolean | helm.template.skip | false | skip template goal. Default value is true due to the dry-run goal
 `<skipDryRun>` | boolean | helm.dry-run.skip | false | skip dry-run goal
 `<skipDependencyBuild>` | boolean | helm.dependency-build.skip | false | skip dependency-build goal
+`<skipDependencyBuildRepoRefresh>` | boolean | helm.dependency-build.skip-repo-refresh | false | skip local repository refresh in dependency-build goal
 `<skipDependencyUpdate>` | boolean | helm.dependency-update.skip | false | skip dependency-update goal
+`<skipDependencyUpdateRepoRefresh>` | boolean | helm.dependency-update.skip-repo-refresh | false | skip local repository refresh in dependency-update goal
 `<skipPackage>` | boolean | helm.package.skip | false | skip package goal
 `<skipUpload>` | boolean | helm.upload.skip | false | skip upload goal
 `<skipCatalog>` | boolean | helm.upload.skip.catalog | true | Skips creation of a catalog file with a list of helm chart upload details

--- a/src/main/java/io/kokuwa/maven/helm/DependencyBuildMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/DependencyBuildMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import io.kokuwa.maven.helm.pojo.HelmExecutable;
 import lombok.Setter;
 
 /**
@@ -28,6 +29,14 @@ public class DependencyBuildMojo extends AbstractDependencyMojo {
 	@Parameter(property = "helm.dependency-build.skip", defaultValue = "false")
 	private boolean skipDependencyBuild;
 
+	/**
+	 * Set this to <code>true</code> to skip refreshing the local repository cache when invoking dependency-build goal.
+	 *
+	 * @since 6.14.0
+	 */
+	@Parameter(property = "helm.dependency-build.skip-repo-refresh", defaultValue = "false")
+	private boolean skipDependencyBuildRepoRefresh;
+
 	@Override
 	public void execute() throws MojoExecutionException {
 
@@ -41,9 +50,12 @@ public class DependencyBuildMojo extends AbstractDependencyMojo {
 			doOverwriteLocalDependencies(chartDirectory);
 
 			getLog().info("Build chart dependencies for " + chartDirectory + " ...");
-			helm()
-					.arguments("dependency", "build", chartDirectory)
-					.execute("Failed to resolve dependencies");
+			HelmExecutable helm = helm()
+					.arguments("dependency", "build", chartDirectory);
+			if (skipDependencyBuildRepoRefresh) {
+				helm.flag("skip-refresh");
+			}
+			helm.execute("Failed to resolve dependencies");
 		}
 	}
 }

--- a/src/main/java/io/kokuwa/maven/helm/DependencyUpdateMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/DependencyUpdateMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import io.kokuwa.maven.helm.pojo.HelmExecutable;
 import lombok.Setter;
 
 /**
@@ -27,6 +28,14 @@ public class DependencyUpdateMojo extends AbstractDependencyMojo {
 	@Parameter(property = "helm.dependency-update.skip", defaultValue = "false")
 	private boolean skipDependencyUpdate;
 
+	/**
+	 * Set this to <code>true</code> to skip refreshing the local repository cache when invoking dependency-update goal.
+	 *
+	 * @since 6.14.0
+	 */
+	@Parameter(property = "helm.dependency-update.skip-repo-refresh", defaultValue = "false")
+	private boolean skipDependencyUpdateRepoRefresh;
+
 	@Override
 	public void execute() throws MojoExecutionException {
 
@@ -40,9 +49,12 @@ public class DependencyUpdateMojo extends AbstractDependencyMojo {
 			doOverwriteLocalDependencies(chartDirectory);
 
 			getLog().info("Updating chart dependencies for " + chartDirectory + " ...");
-			helm()
-					.arguments("dependency", "update", chartDirectory)
-					.execute("Failed to resolve dependencies");
+			HelmExecutable helm = helm()
+					.arguments("dependency", "update", chartDirectory);
+			if (skipDependencyUpdateRepoRefresh) {
+				helm.flag("skip-refresh");
+			}
+			helm.execute("Failed to resolve dependencies");
 		}
 	}
 }

--- a/src/test/java/io/kokuwa/maven/helm/DependencyBuildMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/DependencyBuildMojoTest.java
@@ -58,4 +58,11 @@ public class DependencyBuildMojoTest extends AbstractMojoTest {
 				"dependency build src/test/resources/dependencies/a1",
 				"dependency build src/test/resources/dependencies");
 	}
+
+	@DisplayName("with flag skip repo refresh")
+	@Test
+	void skipRepoRefresh(DependencyBuildMojo mojo) {
+		assertHelm(mojo.setSkipDependencyBuildRepoRefresh(true),
+				"dependency build src/test/resources/simple --skip-refresh");
+	}
 }

--- a/src/test/java/io/kokuwa/maven/helm/DependencyUpdateMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/DependencyUpdateMojoTest.java
@@ -58,4 +58,11 @@ public class DependencyUpdateMojoTest extends AbstractMojoTest {
 				"dependency update src/test/resources/dependencies/a1",
 				"dependency update src/test/resources/dependencies");
 	}
+
+	@DisplayName("with flag skip repo refresh")
+	@Test
+	void skipRepoRefresh(DependencyUpdateMojo mojo) {
+		assertHelm(mojo.setSkipDependencyUpdateRepoRefresh(true),
+				"dependency update src/test/resources/simple --skip-refresh");
+	}
 }


### PR DESCRIPTION
Hello,
This PR adds support for the `--skip-refresh` flag to the dependency-build + dependency-update goals
This will allow improving the build performance of repos with multiple charts as `helm dependency build` is called for each chart resulting in multiple refreshes of the same remote repository


