### PR TITLE
feat: support --pass-credentials option when adding repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Parameter | Type | User Property | Required | Description
 `<repositoryCache>` | string | helm.repositoryCache | false | path to the file containing cached repository indexes
 `<repositoryConfig>` | string | helm.repositoryConfig | false | path to the file containing repository names and URLs
 `<repositoryAddForceUpdate>`| boolean | helm.repo.add.force-update | false | If `true`, replaces (overwrite) the repo if they already exists.
+`<repositoryAddPassCredentials>`| boolean | helm.repo.add.pass-credentials  | false | If `true`, pass credentials to all domains
 `<helmExtraRepos>` | list of [HelmRepository](./src/main/java/io/kokuwa/maven/helm/pojo/HelmRepository.java) | | false | adds extra repositories while init
 `<uploadRepoStable>`| [HelmRepository](./src/main/java/io/kokuwa/maven/helm/pojo/HelmRepository.java) | | false | Upload repository for stable charts
 `<uploadRepoSnapshot>`| [HelmRepository](./src/main/java/io/kokuwa/maven/helm/pojo/HelmRepository.java) | | false | Upload repository for snapshot charts (determined by version postfix 'SNAPSHOT')

--- a/src/main/java/io/kokuwa/maven/helm/InitMojo.java
+++ b/src/main/java/io/kokuwa/maven/helm/InitMojo.java
@@ -103,6 +103,15 @@ public class InitMojo extends AbstractHelmMojo {
 	private boolean repositoryAddForceUpdate;
 
 	/**
+	 * If <code>true</code>, pass credentials to all domains. Can be also specified on repository level in
+	 * "helmExtraRepos".
+	 *
+	 * @since 6.15.0
+	 */
+	@Parameter(property = "helm.repo.add.pass-credentials", defaultValue = "false")
+	private boolean repositoryAddPassCredentials;
+
+	/**
 	 * Download url of helm.
 	 *
 	 * @since 1.0
@@ -210,7 +219,8 @@ public class InitMojo extends AbstractHelmMojo {
 		getLog().info("Adding repo [" + repository + "]");
 		HelmExecutable helm = helm()
 				.arguments("repo", "add", repository.getName(), repository.getUrl())
-				.flag("force-update", repositoryAddForceUpdate || repository.isForceUpdate());
+				.flag("force-update", repositoryAddForceUpdate || repository.isForceUpdate())
+				.flag("pass-credentials", repositoryAddPassCredentials || repository.isPassCredentials());
 		PasswordAuthentication auth = authenticationRequired ? getAuthentication(repository) : null;
 		if (auth != null) {
 			helm.flag("username", auth.getUserName()).flag("password", String.valueOf(auth.getPassword()));

--- a/src/main/java/io/kokuwa/maven/helm/pojo/HelmRepository.java
+++ b/src/main/java/io/kokuwa/maven/helm/pojo/HelmRepository.java
@@ -54,4 +54,12 @@ public class HelmRepository {
 	 * @since 6.6.0
 	 */
 	private boolean forceUpdate = false;
+
+	/**
+	 * If <code>true</code>, pass credentials to all domains (useful when the chart archive is on a different domain
+	 * from the index.yaml, for example on a CDN)
+	 *
+	 * @since 6.15.0
+	 */
+	private boolean passCredentials = false;
 }

--- a/src/test/java/io/kokuwa/maven/helm/InitMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/helm/InitMojoTest.java
@@ -344,6 +344,44 @@ public class InitMojoTest extends AbstractMojoTest {
 				"repo add extra3 https://example.org/extra3");
 	}
 
+	@DisplayName("with flag --pass-credentials")
+	@Test
+	void withPassCredentialsForAll(InitMojo mojo) {
+		mojo.setAddDefaultRepo(true);
+		mojo.setAddUploadRepos(true);
+		mojo.setRepositoryAddPassCredentials(true);
+		mojo.setHelmExtraRepos(new HelmRepository[] { new HelmRepository()
+				.setName("example")
+				.setUrl("https://example.org/repo/example")
+				.setPassCredentials(true) });
+		mojo.setUploadRepoStable(new HelmRepository()
+				.setType(RepoType.ARTIFACTORY)
+				.setName("example-stable")
+				.setUrl("https://example.org/repo/stable"));
+		mojo.setUploadRepoSnapshot(new HelmRepository()
+				.setType(RepoType.ARTIFACTORY)
+				.setName("example-snapshot")
+				.setUrl("https://example.org/repo/snapshot"));
+		assertHelm(mojo,
+				"repo add stable " + InitMojo.STABLE_HELM_REPO + " --pass-credentials",
+				"repo add example-stable https://example.org/repo/stable --pass-credentials",
+				"repo add example-snapshot https://example.org/repo/snapshot --pass-credentials",
+				"repo add example https://example.org/repo/example --pass-credentials");
+	}
+
+	@DisplayName("with flag --pass-credentials for single repository")
+	@Test
+	void withPassCredentialsForSingleRepository(InitMojo mojo) {
+		mojo.setAddDefaultRepo(true);
+		mojo.setHelmExtraRepos(new HelmRepository[] { new HelmRepository()
+				.setName("example")
+				.setUrl("https://example.org/repo/example")
+				.setPassCredentials(true) });
+		assertHelm(mojo,
+				"repo add stable " + InitMojo.STABLE_HELM_REPO,
+				"repo add example https://example.org/repo/example --pass-credentials");
+	}
+
 	private File createTempDirectory() {
 		return assertDoesNotThrow(() -> Files.createTempDirectory("helm-maven-plugin-test")).toFile();
 	}


### PR DESCRIPTION
Add support for the `--pass-credentials` option of the `helm repo add` command
https://helm.sh/docs/helm/helm_repo_add/

This is useful when the chart URLs in the repo index are not on the same domain as the index.yaml